### PR TITLE
Add TooComplexOfType code smell spotter

### DIFF
--- a/org.eclipse.titanium/src/org/eclipse/titanium/markers/spotters/implementation/StaticData.java
+++ b/org.eclipse.titanium/src/org/eclipse/titanium/markers/spotters/implementation/StaticData.java
@@ -78,6 +78,7 @@ public final class StaticData {
 		m.put(CodeSmellType.SIZECHECK_IN_LOOP, new BaseModuleCodeSmellSpotter[] { new SizeCheckInLoop() });
 		m.put(CodeSmellType.STOP_IN_FUNCTION, new BaseModuleCodeSmellSpotter[] { new StopInFunction() });
 		m.put(CodeSmellType.SWITCH_ON_BOOLEAN, new BaseModuleCodeSmellSpotter[] { new SwitchOnBoolean() });
+		m.put(CodeSmellType.TOO_COMPLEX_OF_TYPE, new BaseModuleCodeSmellSpotter[] { new TooComplexOfType() });
 		m.put(CodeSmellType.TOO_COMPLEX_EXPRESSIONS, new BaseModuleCodeSmellSpotter[] { new TooComplexExpression.For(),
 				new TooComplexExpression.While(), new TooComplexExpression.DoWhile(), new TooComplexExpression.If(),
 				new TooComplexExpression.Assignments() });

--- a/org.eclipse.titanium/src/org/eclipse/titanium/markers/spotters/implementation/TooComplexOfType.java
+++ b/org.eclipse.titanium/src/org/eclipse/titanium/markers/spotters/implementation/TooComplexOfType.java
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Copyright (c) 2000-2018 Ericsson Telecom AB
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
+package org.eclipse.titanium.markers.spotters.implementation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.titan.designer.AST.IType;
+import org.eclipse.titan.designer.AST.IVisitableNode;
+import org.eclipse.titan.designer.AST.Type;
+import org.eclipse.titan.designer.AST.TTCN3.definitions.Def_Type;
+import org.eclipse.titan.designer.AST.TTCN3.definitions.Definition;
+import org.eclipse.titan.designer.AST.TTCN3.statements.While_Statement;
+import org.eclipse.titan.designer.AST.TTCN3.types.AbstractOfType;
+import org.eclipse.titan.designer.AST.TTCN3.types.CharString_Type;
+import org.eclipse.titan.designer.AST.TTCN3.types.subtypes.SubType;
+import org.eclipse.titan.designer.parsers.CompilationTimeStamp;
+import org.eclipse.titanium.markers.spotters.BaseModuleCodeSmellSpotter;
+import org.eclipse.titanium.markers.types.CodeSmellType;
+
+public class TooComplexOfType extends BaseModuleCodeSmellSpotter {
+	private static final String ERROR_MESSAGE = "Too complex of type expression. Please consider to create a separate type.";
+	
+	private final CompilationTimeStamp timestamp;
+
+
+	public TooComplexOfType() {
+		super(CodeSmellType.TOO_COMPLEX_OF_TYPE);
+		timestamp = CompilationTimeStamp.getBaseTimestamp();
+	}
+
+	@Override
+	public void process(final IVisitableNode node, final Problems problems) {
+		if (!(node instanceof Def_Type)) {
+			return;
+		}
+		
+		final Def_Type dt = (Def_Type) node; 
+		
+		
+		if(dt.getType(timestamp) instanceof AbstractOfType) {
+			final AbstractOfType aot = (AbstractOfType) dt.getType(timestamp);
+			final IType oft = aot.getOfType();
+			final SubType subt = oft.getSubtype();
+			int a = subt.get_length_restriction();
+						
+						
+			if(oft instanceof AbstractOfType) {
+				problems.report(dt.getLocation(), ERROR_MESSAGE);
+			}
+
+		
+		
+		}
+	}
+
+	@Override
+	public List<Class<? extends IVisitableNode>> getStartNode() {
+		final List<Class<? extends IVisitableNode>> ret = new ArrayList<Class<? extends IVisitableNode>>(1);
+		ret.add(Def_Type.class);
+		return ret;
+	}
+}

--- a/org.eclipse.titanium/src/org/eclipse/titanium/markers/spotters/implementation/TooComplexOfType.java
+++ b/org.eclipse.titanium/src/org/eclipse/titanium/markers/spotters/implementation/TooComplexOfType.java
@@ -9,16 +9,9 @@ package org.eclipse.titanium.markers.spotters.implementation;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.eclipse.titan.designer.AST.IType;
 import org.eclipse.titan.designer.AST.IVisitableNode;
-import org.eclipse.titan.designer.AST.Type;
 import org.eclipse.titan.designer.AST.TTCN3.definitions.Def_Type;
-import org.eclipse.titan.designer.AST.TTCN3.definitions.Definition;
-import org.eclipse.titan.designer.AST.TTCN3.statements.While_Statement;
 import org.eclipse.titan.designer.AST.TTCN3.types.AbstractOfType;
-import org.eclipse.titan.designer.AST.TTCN3.types.CharString_Type;
-import org.eclipse.titan.designer.AST.TTCN3.types.subtypes.SubType;
 import org.eclipse.titan.designer.parsers.CompilationTimeStamp;
 import org.eclipse.titanium.markers.spotters.BaseModuleCodeSmellSpotter;
 import org.eclipse.titanium.markers.types.CodeSmellType;
@@ -28,7 +21,6 @@ public class TooComplexOfType extends BaseModuleCodeSmellSpotter {
 	
 	private final CompilationTimeStamp timestamp;
 
-
 	public TooComplexOfType() {
 		super(CodeSmellType.TOO_COMPLEX_OF_TYPE);
 		timestamp = CompilationTimeStamp.getBaseTimestamp();
@@ -36,26 +28,16 @@ public class TooComplexOfType extends BaseModuleCodeSmellSpotter {
 
 	@Override
 	public void process(final IVisitableNode node, final Problems problems) {
-		if (!(node instanceof Def_Type)) {
-			return;
-		}
-		
-		final Def_Type dt = (Def_Type) node; 
-		
-		
-		if(dt.getType(timestamp) instanceof AbstractOfType) {
-			final AbstractOfType aot = (AbstractOfType) dt.getType(timestamp);
-			final IType oft = aot.getOfType();
-			final SubType subt = oft.getSubtype();
-			int a = subt.get_length_restriction();
-						
-						
-			if(oft instanceof AbstractOfType) {
-				problems.report(dt.getLocation(), ERROR_MESSAGE);
+		if (node instanceof Def_Type) {
+			final Def_Type dt = (Def_Type) node; 
+			if(dt.getType(timestamp) instanceof AbstractOfType) {
+				final AbstractOfType aot = (AbstractOfType) dt.getType(timestamp);			
+				if(aot.getOfType().getSubtype() != null) {
+					problems.report(dt.getLocation(), ERROR_MESSAGE);
+				}else if(aot.getOfType() instanceof AbstractOfType) {
+					problems.report(dt.getLocation(), ERROR_MESSAGE);
+				}
 			}
-
-		
-		
 		}
 	}
 

--- a/org.eclipse.titanium/src/org/eclipse/titanium/markers/types/CodeSmellType.java
+++ b/org.eclipse.titanium/src/org/eclipse/titanium/markers/types/CodeSmellType.java
@@ -56,6 +56,7 @@ public enum CodeSmellType implements ProblemType{
 	SIZECHECK_IN_LOOP("Size check in loop", 0.0, 1.0, 5.0),
 	STOP_IN_FUNCTION("Stop in function", 0.5, 2.5, 50.0),
 	SWITCH_ON_BOOLEAN("Switch on boolean", 0.5, 1.0, 2.0),
+	TOO_COMPLEX_OF_TYPE("Too complex of type", 0.0, 0.0, 0.0), // 0.0, 0.0, 0.0 FIXME
 	TOO_COMPLEX_EXPRESSIONS("Too complex expression", 1.0, 2.0, 8.0),
 	TOO_MANY_PARAMETERS("Too many parameters", 1.0, 3.0, 37.0),
 	TOO_MANY_STATEMENTS("Too many statements", 2.0, 6.0, 50.0),

--- a/org.eclipse.titanium/src/org/eclipse/titanium/preferences/PreferenceInitializer.java
+++ b/org.eclipse.titanium/src/org/eclipse/titanium/preferences/PreferenceInitializer.java
@@ -88,6 +88,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		preferenceStore.setDefault(ProblemTypePreference.ISVALUE_WITH_VALUE.getPreferenceName(), GeneralConstants.IGNORE);
 		preferenceStore.setDefault(ProblemTypePreference.ITERATE_ON_WRONG_ARRAY.getPreferenceName(), GeneralConstants.IGNORE);
 		preferenceStore.setDefault(ProblemTypePreference.CONSECUTIVE_ASSIGNMENTS.getPreferenceName(), GeneralConstants.IGNORE);
+		preferenceStore.setDefault(ProblemTypePreference.TOO_COMPLEX_OF_TYPE.getPreferenceName(), GeneralConstants.WARNING);
 		preferenceStore.setDefault(PreferenceConstants.TOO_MANY_CONSECUTIVE_ASSIGNMENTS_SIZE, 4);
 		preferenceStore.setDefault(ProblemTypePreference.CONVERT_TO_ENUM.getPreferenceName(), GeneralConstants.IGNORE);
 		preferenceStore.setDefault(ProblemTypePreference.SELECT_COVERAGE.getPreferenceName(), GeneralConstants.IGNORE);
@@ -170,6 +171,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		// SemanticProblemType.INCORRECT_SHIFT_ROTATE_SIZE, 2, ); // TODO:
 		// missing label in ExRotSize in the xls
 		setSmellImpactAndBaseLine(preferenceStore, CodeSmellType.SIZECHECK_IN_LOOP, 2, 1000);
+		setSmellImpactAndBaseLine(preferenceStore, CodeSmellType.TOO_COMPLEX_OF_TYPE, 2, 2000);
 		setSmellImpactAndBaseLine(preferenceStore, CodeSmellType.TOO_COMPLEX_EXPRESSIONS, 2, 1000);
 		setSmellImpactAndBaseLine(preferenceStore, CodeSmellType.READONLY_INOUT_PARAM, 2, 4000);
 		setSmellImpactAndBaseLine(preferenceStore, CodeSmellType.READONLY_OUT_PARAM, 2, 50000);

--- a/org.eclipse.titanium/src/org/eclipse/titanium/preferences/ProblemTypePreference.java
+++ b/org.eclipse.titanium/src/org/eclipse/titanium/preferences/ProblemTypePreference.java
@@ -61,6 +61,7 @@ public enum ProblemTypePreference {
 	RECEIVE_ANY_TEMPLATE("Report receive statements accepting any value", EnumSet.of(CodeSmellType.RECEIVE_ANY_TEMPLATE)),
 	STOP_IN_FUNCTION("Report stop statement in functions", EnumSet.of(CodeSmellType.STOP_IN_FUNCTION)),
 	SWITCH_ON_BOOLEAN("Report switching on boolean value", EnumSet.of(CodeSmellType.SWITCH_ON_BOOLEAN)),
+	TOO_COMPLEX_OF_TYPE("Report the too complex of type usage", EnumSet.of(CodeSmellType.TOO_COMPLEX_OF_TYPE)),
 	TOO_COMPLEX_EXPRESSIONS("Report TTCN-3 expressions that are too complex", EnumSet.of(CodeSmellType.TOO_COMPLEX_EXPRESSIONS)),
 	TOO_MANY_PARAMETERS("Report TTCN-3 definitions that have too many parameters", EnumSet.of(CodeSmellType.TOO_MANY_PARAMETERS)),
 	TOO_MANY_STATEMENTS("Report statement blocks that have too many statements", EnumSet.of(CodeSmellType.TOO_MANY_STATEMENTS)),


### PR DESCRIPTION
Create a code smell spotter to identifying too complex of types and ask the developer to create a separate type for them.